### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-networkx
+networkx==2.6.0
 pip-chill
 torchvision
 pyyaml


### PR DESCRIPTION
Locking the version for the networkx package. 
The functions `read_gpickle` and `write_gpickle` were removed in 3.0 version of that package: https://github.com/networkx/networkx/blob/740e981a29385cafd6df3cd6c3d612f9e9e54b3d/doc/release/migration_guide_from_2.x_to_3.0.rst